### PR TITLE
Load clear-globals after global timer mocks load

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,14 @@
 
 var clearAjax = require('@segment/clear-ajax');
 var clearCookies = require('@segment/clear-cookies');
-var clearGlobals = require('@segment/clear-globals');
 var clearImages = require('@segment/clear-images');
-var clearIntervals = require('@segment/clear-intervals');
 var clearListeners = require('@segment/clear-listeners');
 var clearScripts = require('@segment/clear-scripts');
+var clearIntervals = require('@segment/clear-intervals');
 var clearTimeouts = require('@segment/clear-timeouts');
+// Load clear-globals only after clear-intervals and clear-timeouts to prevent
+// overriding those packages' setTimeout/setInterval mocks
+var clearGlobals = require('@segment/clear-globals');
 
 /**
  * Reset initial state.

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "@segment/clear-cookies": "^1.0.0",
     "@segment/clear-globals": "^1.0.0",
     "@segment/clear-images": "^1.0.0",
-    "@segment/clear-intervals": "^1.0.0",
+    "@segment/clear-intervals": "^2.0.0",
     "@segment/clear-listeners": "^1.0.0",
     "@segment/clear-scripts": "^1.0.0",
-    "@segment/clear-timeouts": "^1.0.0"
+    "@segment/clear-timeouts": "^2.0.0"
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.1.1",


### PR DESCRIPTION
If clear-globals loads before clear-intervals and clear-timeouts, it
will end up removing those modules' timer mocks. This fixes that issue.