### PR TITLE
Bump @segment/clear-cookies to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/clear-env",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Clear cookies, images, script tags, native methods, timers, and event listeners for a clean test slate",
   "keywords": [],
   "main": "lib/index.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/segmentio/clear-env#readme",
   "dependencies": {
     "@segment/clear-ajax": "^1.0.2",
-    "@segment/clear-cookies": "^2.0.0",
+    "@segment/clear-cookies": "^2.0.1",
     "@segment/clear-globals": "^1.0.0",
     "@segment/clear-images": "^1.0.0",
     "@segment/clear-intervals": "^2.0.0",


### PR DESCRIPTION
`component-cookie` used to depend on `debug: *`, which has caused problems for upstream dependents on this package. The newest version of `component-cookie`, `1.1.4`, fixes this issue. `clear-cookies`, which depends on `component-cookie`, has been fixed in `2.0.1`.

See: https://github.com/segmentio/clear-cookies/pull/3 https://github.com/component/cookie/pull/15